### PR TITLE
Better heading styles for the doc view

### DIFF
--- a/lib/modelica-doc-view.coffee
+++ b/lib/modelica-doc-view.coffee
@@ -100,7 +100,7 @@ class ModelicaDocView extends ScrollView
         name = blockmatch[2]
         endregex = new RegExp "\bend\b\s*\b" + name + "\b"
         endregex = new RegExp "end " + name + ";"
-        anns1 += "<hr class='level" + level + "'/><h" + level + ">" + blockmatch[0] + "</h" + level + ">"
+        anns1 += "<h" + level + ">" + blockmatch[0] + "</h" + level + ">"
         for erow in [stoprow..(row + 1)]
           if @editor.lineTextForBufferRow(erow).match(endregex)
             anns1 += @extractHTML(row + 1, erow - 1, level + 1)

--- a/lib/modelica-doc-view.coffee
+++ b/lib/modelica-doc-view.coffee
@@ -100,7 +100,7 @@ class ModelicaDocView extends ScrollView
         name = blockmatch[2]
         endregex = new RegExp "\bend\b\s*\b" + name + "\b"
         endregex = new RegExp "end " + name + ";"
-        anns1 += "<h" + level + ">" + blockmatch[0] + "</h" + level + ">"
+        anns1 += "<hr class='level" + level + "'/><h" + level + ">" + blockmatch[0] + "</h" + level + ">"
         for erow in [stoprow..(row + 1)]
           if @editor.lineTextForBufferRow(erow).match(endregex)
             anns1 += @extractHTML(row + 1, erow - 1, level + 1)

--- a/styles/modelica.less
+++ b/styles/modelica.less
@@ -16,3 +16,49 @@
     border: 0;
   }
 }
+
+.modelica-doc-view .markdown-preview h1 {
+  border-top: 3px solid #09104f;
+  border-bottom: 3px solid #09104f;
+  color: #17377e;
+  background-color: #999999;
+}
+
+.modelica-doc-view .markdown-preview h2 {
+  border-top: 2px solid #09104f;
+  color: #17377e;
+  background-color: #999999;
+  line-height: 130%;
+}
+
+.modelica-doc-view .markdown-preview h3 {
+  border-top: 1px solid #7a7a7a;
+  line-height: 130%;
+}
+
+.modelica-doc-view .markdown-preview h4::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  width: 50%;
+  border-top: 1px solid #7a7a7a;
+}
+
+.modelica-doc-view .markdown-preview h5::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  width: 25%;
+  border-top: 1px solid #7a7a7a;
+}
+
+.modelica-doc-view .markdown-preview h6::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  width: 15%;
+  border-top: 1px solid #7a7a7a;
+}


### PR DESCRIPTION
This addresses #25. I started by adding a horizontal rule, but it's better to adjust the styling on the headings. Each of the headings has better differentiation, so the user can more easily see what level they're looking at.
